### PR TITLE
Fix typo on README.md showing how to install dev prereqs (#154)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ To install the latest ("cutting-edge") GitHub version run:
 
 # good packages to install for this to work smoothly:
 
-install.packages("Rcpp", "ggplot2","munsell","htmltools","DBI","assertthat","gridExtra",
-'devtools',"fpc","TSP","registry","gclus","gplots","RColorBrewer",
-"stringr","labeling","yaml")
+install.packages(c("Rcpp","ggplot2","munsell","htmltools","DBI","assertthat",
+"gridExtra","digest","fpc","TSP","registry","gclus","gplots","RColorBrewer",
+"stringr","labeling","yaml"))
 
 # You'll need devtools
 install.packages.2 <- function (pkg) if (!require(pkg)) install.packages(pkg);


### PR DESCRIPTION
Fix typo in command to install dev prereqs

Original forgot to combine package names into a vector.
digest needed for plotly and devtools installed conditionally after initial install.